### PR TITLE
Always return an object for locals, even if it's empty

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,9 @@ module.exports = function spikeHtmlStandards (options = {}) {
   let parserOpt = options.parser || sugarml
   if (options.parser === false) parserOpt = undefined
 
+  // Always return an object for locals
+  if (typeof options.locals === 'undefined') options.locals = {}
+
   // If the user has not overridden the default markdown function, initialize
   // markdown-it and add the default
   let contentOpt = options.content || {}


### PR DESCRIPTION
This should fix https://github.com/static-dev/spike-core/issues/179
